### PR TITLE
GitHub Actionsのワークフローを2つ新規作成しました。1つ目はプルリクエストの自動著者割り当てを行う`auto-author-…

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,17 @@
+name: 'Auto Author Assign'
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: toshimaru/auto-author-assign@v2.1.1
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,0 +1,33 @@
+name: 'Validate PR title'
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    # dependabotでは `secrets.GITHUB_TOKEN` を参照できないためスキップ
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # https://github.com/amannn/action-semantic-pull-request#configuration
+        with:
+          # タイトルのprefixに [WIP] があれば検証を保留にする
+          wip: true
+          # これらのラベルが付いているものは検証の対象外にする
+          ignoreLabels: |
+            bot
+            ignore-semantic-pull-request
+          # 許可するスコープ。スコープとは、コミットの型の後ろに書いてある丸括弧の中身のこと
+          # e.g. "chore(deps)" の "deps" の部分
+          scopes: |
+            deps
+            deps-dev


### PR DESCRIPTION
…assign.yml`、2つ目はプルリクエストのタイトルを検証する`validate-pr-title.yml`です。